### PR TITLE
[멧돼지] 뷰 챌린지 미션 1단계 제출합니다. 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
         }
     }
@@ -32,6 +32,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+    }
+    dataBinding {
+        enable = true
     }
 }
 

--- a/app/src/main/java/woowacourse/paint/MainActivity.kt
+++ b/app/src/main/java/woowacourse/paint/MainActivity.kt
@@ -11,7 +11,6 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
     }

--- a/app/src/main/java/woowacourse/paint/MainActivity.kt
+++ b/app/src/main/java/woowacourse/paint/MainActivity.kt
@@ -2,13 +2,17 @@ package woowacourse.paint
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-
+import androidx.databinding.DataBindingUtil
+import woowacourse.paint.databinding.ActivityMainBindingImpl
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBindingImpl
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
     }
 }

--- a/app/src/main/java/woowacourse/paint/MainActivity.kt
+++ b/app/src/main/java/woowacourse/paint/MainActivity.kt
@@ -3,11 +3,11 @@ package woowacourse.paint
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import woowacourse.paint.databinding.ActivityMainBindingImpl
+import woowacourse.paint.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var binding: ActivityMainBindingImpl
+    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -19,12 +19,6 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
             TwoPointerDragListener(this, screenWidth, screenHeight),
         )
 
-    private val pinchZoomScaleDetector =
-        ScaleGestureDetector(
-            context,
-            PinchZoomListener(this),
-        )
-
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         adjustBoardSize()
@@ -42,7 +36,6 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         twoPointerDragScaleDetector.onTouchEvent(event)
-//        pinchZoomScaleDetector.onTouchEvent(event)
         return true
     }
 

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -27,7 +27,10 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     private val twoPointerDragScaleDetector =
         ScaleGestureDetector(
             context,
-            TwoPointerDragListener(this, screenWidth, screenHeight),
+            TwoPointerDragListener(this, screenWidth, screenHeight) {
+                palette.x = -x
+                palette.y = -y
+            },
         )
 
     init {
@@ -45,8 +48,18 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     }
 
     private fun moveScreenToBoardCenter() {
+        moveBoardToCenter()
+        movePaletteToCenter()
+    }
+
+    private fun moveBoardToCenter() {
         x = (-expandedWidth / 2 + screenWidth / 2).toFloat()
         y = (-expandedHeight / 2 + screenHeight / 2).toFloat()
+    }
+
+    private fun movePaletteToCenter() {
+        palette.x = -(-expandedWidth / 2 + screenWidth / 2).toFloat()
+        palette.y = -(-expandedHeight / 2 + screenHeight / 2).toFloat()
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -6,10 +6,13 @@ import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
+import android.view.ViewGroup.LayoutParams
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 import woowacourse.paint.board.draw.GraphicObject
 import woowacourse.paint.board.draw.Line
+import woowacourse.paint.palette.Palette
 
 class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
     private val screenWidth = resources.displayMetrics.widthPixels
@@ -19,11 +22,17 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
 
     private val graphicObjects: MutableList<GraphicObject> = mutableListOf()
 
+    private lateinit var palette: Palette
+
     private val twoPointerDragScaleDetector =
         ScaleGestureDetector(
             context,
             TwoPointerDragListener(this, screenWidth, screenHeight),
         )
+
+    init {
+        addStickyPalette()
+    }
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
@@ -57,6 +66,12 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         graphicObjects.forEach { it.onDrawAction(canvas) }
+    }
+
+    private fun addStickyPalette() {
+        palette = Palette(context)
+        palette.layoutParams = FrameLayout.LayoutParams(screenWidth, WRAP_CONTENT)
+        addView(palette)
     }
 
     companion object {

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -92,10 +92,10 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
 
     private fun addStickyPalette() {
         palette = Palette(
-            context,
-            null,
-            ::onSelectedColorIdChangedListener,
-            ::onStrokeWidthChangedListener,
+            context = context,
+            attrs = null,
+            onSelectedColorIdChangedListener = ::onSelectedColorIdChangedListener,
+            onStrokeWidthChangedListener = ::onStrokeWidthChangedListener,
         )
         palette.layoutParams = FrameLayout.LayoutParams(screenWidth, WRAP_CONTENT)
         addView(palette)

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -2,14 +2,19 @@ package woowacourse.paint.board
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 
 class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
     private val screenWidth = resources.displayMetrics.widthPixels
     private val screenHeight = resources.displayMetrics.heightPixels
-    private val expandedWidth = screenWidth * BOARD_EXPANSION_RATE
-    private val expandedHeight = screenHeight * BOARD_EXPANSION_RATE
+    private val expandedWidth = screenWidth * BOARD_WIDTH_EXPANSION_RATE
+    private val expandedHeight = screenHeight * BOARD_HEIGHT_EXPANSION_RATE
+
+    private val pinchZoomTwoPointerDragScaleDetector =
+        ScaleGestureDetector(context, PinchZoomTwoPointerDragListener(this))
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
@@ -22,11 +27,17 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     }
 
     private fun moveScreenToBoardCenter() {
-        translationX = (-expandedWidth / 2 + screenWidth / 2).toFloat()
-        translationY = (-expandedHeight / 2 + screenHeight / 2).toFloat()
+        x = (-expandedWidth / 2 + screenWidth / 2).toFloat()
+        y = (-expandedHeight / 2 + screenHeight / 2).toFloat()
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        pinchZoomTwoPointerDragScaleDetector.onTouchEvent(event)
+        return true
     }
 
     companion object {
-        private const val BOARD_EXPANSION_RATE = 5
+        private const val BOARD_HEIGHT_EXPANSION_RATE = 5
+        private const val BOARD_WIDTH_EXPANSION_RATE = 15
     }
 }

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -6,10 +6,11 @@ import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
-import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
+import androidx.annotation.ColorRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import woowacourse.paint.R
 import woowacourse.paint.board.draw.GraphicObject
 import woowacourse.paint.board.draw.Line
 import woowacourse.paint.palette.Palette
@@ -21,6 +22,10 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     private val expandedHeight = screenHeight * BOARD_HEIGHT_EXPANSION_RATE
 
     private val graphicObjects: MutableList<GraphicObject> = mutableListOf()
+
+    @ColorRes
+    private var currentSelectedColor: Int = R.color.black
+    private var currentStrokeWidth: Float = 10f
 
     private lateinit var palette: Palette
 
@@ -69,7 +74,11 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
 
     private fun lineEvent(event: MotionEvent): Boolean {
         if (event.action == MotionEvent.ACTION_DOWN) {
-            val line: Line = Line(Paint(), 10f, ::invalidate)
+            val line: Line = Line(
+                Paint().apply { color = context.getColor(currentSelectedColor) },
+                currentStrokeWidth,
+                ::invalidate,
+            )
             graphicObjects.add(line)
         }
         graphicObjects.last().onTouchEventAction(event)
@@ -82,9 +91,22 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     }
 
     private fun addStickyPalette() {
-        palette = Palette(context)
+        palette = Palette(
+            context,
+            null,
+            ::onSelectedColorIdChangedListener,
+            ::onStrokeWidthChangedListener,
+        )
         palette.layoutParams = FrameLayout.LayoutParams(screenWidth, WRAP_CONTENT)
         addView(palette)
+    }
+
+    private fun onSelectedColorIdChangedListener(colorId: Int) {
+        currentSelectedColor = colorId
+    }
+
+    private fun onStrokeWidthChangedListener(strokeWidth: Float) {
+        currentStrokeWidth = strokeWidth
     }
 
     companion object {

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -1,0 +1,32 @@
+package woowacourse.paint.board
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.constraintlayout.widget.ConstraintLayout
+
+class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
+    private val screenWidth = resources.displayMetrics.widthPixels
+    private val screenHeight = resources.displayMetrics.heightPixels
+    private val expandedWidth = screenWidth * BOARD_EXPANSION_RATE
+    private val expandedHeight = screenHeight * BOARD_EXPANSION_RATE
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        adjustBoardSize()
+        moveScreenToBoardCenter()
+    }
+
+    private fun adjustBoardSize() {
+        layoutParams = FrameLayout.LayoutParams(expandedWidth, expandedHeight)
+    }
+
+    private fun moveScreenToBoardCenter() {
+        translationX = (-expandedWidth / 2 + screenWidth / 2).toFloat()
+        translationY = (-expandedHeight / 2 + screenHeight / 2).toFloat()
+    }
+
+    companion object {
+        private const val BOARD_EXPANSION_RATE = 5
+    }
+}

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -41,11 +41,8 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        return when (event.pointerCount) {
-            2 -> twoPointerDragScaleDetector.onTouchEvent(event)
-            1 -> lineEvent(event)
-            else -> super.onTouchEvent(event)
-        }
+        twoPointerDragScaleDetector.onTouchEvent(event)
+        return twoPointerDragScaleDetector.isInProgress || lineEvent(event)
     }
 
     private fun lineEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -13,10 +13,16 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     private val expandedWidth = screenWidth * BOARD_WIDTH_EXPANSION_RATE
     private val expandedHeight = screenHeight * BOARD_HEIGHT_EXPANSION_RATE
 
-    private val pinchZoomTwoPointerDragScaleDetector =
+    private val twoPointerDragScaleDetector =
         ScaleGestureDetector(
             context,
-            PinchZoomTwoPointerDragListener(this, screenWidth, screenHeight),
+            TwoPointerDragListener(this, screenWidth, screenHeight),
+        )
+
+    private val pinchZoomScaleDetector =
+        ScaleGestureDetector(
+            context,
+            PinchZoomListener(this),
         )
 
     override fun onAttachedToWindow() {
@@ -35,7 +41,8 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        pinchZoomTwoPointerDragScaleDetector.onTouchEvent(event)
+        twoPointerDragScaleDetector.onTouchEvent(event)
+//        pinchZoomScaleDetector.onTouchEvent(event)
         return true
     }
 

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -14,7 +14,10 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     private val expandedHeight = screenHeight * BOARD_HEIGHT_EXPANSION_RATE
 
     private val pinchZoomTwoPointerDragScaleDetector =
-        ScaleGestureDetector(context, PinchZoomTwoPointerDragListener(this))
+        ScaleGestureDetector(
+            context,
+            PinchZoomTwoPointerDragListener(this, screenWidth, screenHeight),
+        )
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()

--- a/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
+++ b/app/src/main/java/woowacourse/paint/board/PaintBoard.kt
@@ -1,17 +1,23 @@
 package woowacourse.paint.board
 
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
+import woowacourse.paint.board.draw.GraphicObject
+import woowacourse.paint.board.draw.Line
 
 class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
     private val screenWidth = resources.displayMetrics.widthPixels
     private val screenHeight = resources.displayMetrics.heightPixels
     private val expandedWidth = screenWidth * BOARD_WIDTH_EXPANSION_RATE
     private val expandedHeight = screenHeight * BOARD_HEIGHT_EXPANSION_RATE
+
+    private val graphicObjects: MutableList<GraphicObject> = mutableListOf()
 
     private val twoPointerDragScaleDetector =
         ScaleGestureDetector(
@@ -35,8 +41,25 @@ class PaintBoard(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        twoPointerDragScaleDetector.onTouchEvent(event)
+        return when (event.pointerCount) {
+            2 -> twoPointerDragScaleDetector.onTouchEvent(event)
+            1 -> lineEvent(event)
+            else -> super.onTouchEvent(event)
+        }
+    }
+
+    private fun lineEvent(event: MotionEvent): Boolean {
+        if (event.action == MotionEvent.ACTION_DOWN) {
+            val line: Line = Line(Paint(), 10f, ::invalidate)
+            graphicObjects.add(line)
+        }
+        graphicObjects.last().onTouchEventAction(event)
         return true
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        graphicObjects.forEach { it.onDrawAction(canvas) }
     }
 
     companion object {

--- a/app/src/main/java/woowacourse/paint/board/PinchZoomListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/PinchZoomListener.kt
@@ -1,0 +1,36 @@
+package woowacourse.paint.board
+
+import android.view.ScaleGestureDetector
+import android.view.View
+
+class PinchZoomListener(private val targetView: View) :
+    ScaleGestureDetector.SimpleOnScaleGestureListener() {
+
+    private var currentScaleFactor: Float = 1f
+
+    private var lastSpan: Float = 0f
+
+    override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+        super.onScaleBegin(detector)
+        lastSpan = detector.currentSpan
+        return true
+    }
+
+    override fun onScale(detector: ScaleGestureDetector): Boolean {
+        super.onScale(detector)
+        val currentSpan: Float = detector.currentSpan
+
+        currentScaleFactor *= 1 + (lastSpan / currentSpan - 1) * 0.2f
+
+        currentScaleFactor = Math.max(0.2f, Math.min(currentScaleFactor, 5.0f))
+
+        targetView.animate()
+            .scaleX(currentScaleFactor)
+            .scaleY(currentScaleFactor)
+            .setDuration(0)
+            .start()
+
+        lastSpan = currentSpan
+        return true
+    }
+}

--- a/app/src/main/java/woowacourse/paint/board/PinchZoomListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/PinchZoomListener.kt
@@ -20,7 +20,7 @@ class PinchZoomListener(private val targetView: View) :
         super.onScale(detector)
         val currentSpan: Float = detector.currentSpan
 
-        currentScaleFactor *= 1 + (lastSpan / currentSpan - 1) * 0.2f
+        currentScaleFactor *= 1 + (currentSpan / lastSpan - 1) * 0.2f
 
         currentScaleFactor = Math.max(0.2f, Math.min(currentScaleFactor, 5.0f))
 

--- a/app/src/main/java/woowacourse/paint/board/PinchZoomListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/PinchZoomListener.kt
@@ -19,18 +19,37 @@ class PinchZoomListener(private val targetView: View) :
     override fun onScale(detector: ScaleGestureDetector): Boolean {
         super.onScale(detector)
         val currentSpan: Float = detector.currentSpan
+        calculateScaleFactor(currentSpan)
+        limitScaleFactor()
+        applyScaleFactorToView()
+        lastSpan = currentSpan
+        return true
+    }
 
-        currentScaleFactor *= 1 + (currentSpan / lastSpan - 1) * 0.2f
-
-        currentScaleFactor = Math.max(0.2f, Math.min(currentScaleFactor, 5.0f))
-
+    private fun applyScaleFactorToView() {
         targetView.animate()
             .scaleX(currentScaleFactor)
             .scaleY(currentScaleFactor)
             .setDuration(0)
             .start()
+    }
 
-        lastSpan = currentSpan
-        return true
+    private fun calculateScaleFactor(currentSpan: Float) {
+        currentScaleFactor *= 1 + (getScaleRatio(currentSpan)) * SCALE_CORRECTION_FACTOR
+    }
+
+    /**
+     * 음수를 반환하면 zoom out, 양수를 반환하면 zoom in 상황을 뜻한다.
+     */
+    private fun getScaleRatio(currentSpan: Float) = currentSpan / lastSpan - 1
+
+    private fun limitScaleFactor() {
+        currentScaleFactor = Math.max(MINIMUM_SCALE_DOWN_VALUE, Math.min(currentScaleFactor, MAXIMUM_SCALE_UP_VALUE))
+    }
+
+    companion object {
+        const val SCALE_CORRECTION_FACTOR = 0.2F
+        const val MINIMUM_SCALE_DOWN_VALUE = 1f / 5f
+        const val MAXIMUM_SCALE_UP_VALUE = 5f
     }
 }

--- a/app/src/main/java/woowacourse/paint/board/PinchZoomTwoPointerDragListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/PinchZoomTwoPointerDragListener.kt
@@ -1,0 +1,42 @@
+package woowacourse.paint.board
+
+import android.view.ScaleGestureDetector
+import android.view.View
+
+/**
+ * 그림판에 적용하기 위한 ScaleGestureListener로 두가지 사양을 제공한다.
+ * 1.핀치줌 : 어느 지점이든 핀치줌을 사용할 수 있다.
+ * 2.두 손가락 드래그 : 그림판이기 때문에 두 손가락을 이용해서 드래그 및 이동을 할수 있도록 설정 하였다.
+ */
+class PinchZoomTwoPointerDragListener(private val targetView: View) :
+    ScaleGestureDetector.SimpleOnScaleGestureListener() {
+
+    private var lastFocusX: Float = 0f
+    private var lastFocusY: Float = 0f
+
+    override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+        lastFocusX = detector.focusX
+        lastFocusY = detector.focusY
+        return true
+    }
+
+    override fun onScale(detector: ScaleGestureDetector): Boolean {
+        val currentFocusX = detector.focusX
+        val currentFocusY = detector.focusY
+
+        targetView.animate()
+            .x(targetView.x + (lastFocusX - currentFocusX) * DRAG_ADJUST_VALUE)
+            .y(targetView.y + (lastFocusY - currentFocusY) * DRAG_ADJUST_VALUE)
+            .setDuration(0)
+            .start()
+
+        lastFocusX = currentFocusX
+        lastFocusY = currentFocusY
+
+        return true
+    }
+
+    companion object {
+        private const val DRAG_ADJUST_VALUE = 0.75f
+    }
+}

--- a/app/src/main/java/woowacourse/paint/board/TwoPointerDragListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/TwoPointerDragListener.kt
@@ -13,7 +13,6 @@ class TwoPointerDragListener(
     private var lastFocusY: Float = 0f
 
     override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
-        super.onScaleBegin(detector)
         twoPointerDragOnScaleBegin(detector)
         return true
     }
@@ -24,7 +23,6 @@ class TwoPointerDragListener(
     }
 
     override fun onScale(detector: ScaleGestureDetector): Boolean {
-        super.onScale(detector)
         twoPointerDragOnScale(detector)
         return true
     }

--- a/app/src/main/java/woowacourse/paint/board/TwoPointerDragListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/TwoPointerDragListener.kt
@@ -3,22 +3,17 @@ package woowacourse.paint.board
 import android.view.ScaleGestureDetector
 import android.view.View
 
-/**
- * 그림판에 적용하기 위한 ScaleGestureListener로 두가지 사양을 제공한다.
- * 1.핀치줌 : 어느 지점이든 핀치줌을 사용할 수 있다.
- * 2.두 손가락 드래그 : 그림판이기 때문에 두 손가락을 이용해서 드래그 및 이동을 할수 있도록 설정 하였다.
- */
-class PinchZoomTwoPointerDragListener(
+class TwoPointerDragListener(
     private val targetView: View,
     private val screenWidth: Int,
     private val screenHeight: Int,
-) :
-    ScaleGestureDetector.SimpleOnScaleGestureListener() {
+) : ScaleGestureDetector.SimpleOnScaleGestureListener() {
 
     private var lastFocusX: Float = 0f
     private var lastFocusY: Float = 0f
 
     override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+        super.onScaleBegin(detector)
         twoPointerDragOnScaleBegin(detector)
         return true
     }
@@ -29,6 +24,7 @@ class PinchZoomTwoPointerDragListener(
     }
 
     override fun onScale(detector: ScaleGestureDetector): Boolean {
+        super.onScale(detector)
         twoPointerDragOnScale(detector)
         return true
     }

--- a/app/src/main/java/woowacourse/paint/board/TwoPointerDragListener.kt
+++ b/app/src/main/java/woowacourse/paint/board/TwoPointerDragListener.kt
@@ -7,6 +7,7 @@ class TwoPointerDragListener(
     private val targetView: View,
     private val screenWidth: Int,
     private val screenHeight: Int,
+    private val onScreenMoveListener: () -> Unit,
 ) : ScaleGestureDetector.SimpleOnScaleGestureListener() {
 
     private var lastFocusX: Float = 0f
@@ -41,6 +42,8 @@ class TwoPointerDragListener(
             destinationXPreventOverScroll,
             destinationYPreventOverScroll,
         )
+
+        onScreenMoveListener()
 
         lastFocusX = currentFocusX
         lastFocusY = currentFocusY

--- a/app/src/main/java/woowacourse/paint/board/draw/GraphicObject.kt
+++ b/app/src/main/java/woowacourse/paint/board/draw/GraphicObject.kt
@@ -1,0 +1,11 @@
+package woowacourse.paint.board.draw
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.view.MotionEvent
+
+interface GraphicObject {
+    val paint: Paint
+    fun onTouchEventAction(event: MotionEvent): Boolean
+    fun onDrawAction(canvas: Canvas)
+}

--- a/app/src/main/java/woowacourse/paint/board/draw/Line.kt
+++ b/app/src/main/java/woowacourse/paint/board/draw/Line.kt
@@ -1,0 +1,35 @@
+package woowacourse.paint.board.draw
+
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.view.MotionEvent
+
+class Line(override val paint: Paint, strokeWidth: Float, private val invalidateView: () -> Unit) :
+    GraphicObject {
+
+    private val path = Path()
+
+    init {
+        paint.apply {
+            this.strokeWidth = strokeWidth
+            style = Paint.Style.STROKE
+        }
+    }
+
+    override fun onTouchEventAction(event: MotionEvent): Boolean {
+        val pointX = event.x
+        val pointY = event.y
+
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> path.moveTo(pointX, pointY)
+            MotionEvent.ACTION_MOVE -> path.lineTo(pointX, pointY)
+        }
+        invalidateView()
+        return true
+    }
+
+    override fun onDrawAction(canvas: Canvas) {
+        canvas.drawPath(path, paint)
+    }
+}

--- a/app/src/main/java/woowacourse/paint/board/draw/Line.kt
+++ b/app/src/main/java/woowacourse/paint/board/draw/Line.kt
@@ -24,6 +24,7 @@ class Line(override val paint: Paint, strokeWidth: Float, private val invalidate
         when (event.action) {
             MotionEvent.ACTION_DOWN -> path.moveTo(pointX, pointY)
             MotionEvent.ACTION_MOVE -> path.lineTo(pointX, pointY)
+            MotionEvent.ACTION_UP -> path.lineTo(pointX, pointY)
         }
         invalidateView()
         return true

--- a/app/src/main/java/woowacourse/paint/common/BindingAdapter.kt
+++ b/app/src/main/java/woowacourse/paint/common/BindingAdapter.kt
@@ -1,0 +1,10 @@
+package woowacourse.paint.common
+
+import android.view.View
+import androidx.annotation.ColorRes
+import androidx.databinding.BindingAdapter
+
+@BindingAdapter("app:setBackGroundColor")
+fun View.setBackGroundColor(@ColorRes colorId: Int) {
+    setBackgroundColor(context.getColor(colorId))
+}

--- a/app/src/main/java/woowacourse/paint/palette/Color.kt
+++ b/app/src/main/java/woowacourse/paint/palette/Color.kt
@@ -4,5 +4,7 @@ import androidx.annotation.ColorRes
 import woowacourse.paint.R
 
 enum class Color(@ColorRes val resId: Int) {
-    RED(R.color.red), ORANGE(R.color.orange), YELLOW(R.color.yellow), GREEN(R.color.green), BLUE(R.color.blue)
+    BLACK(R.color.black), RED(R.color.red), ORANGE(R.color.orange), YELLOW(R.color.yellow), GREEN(R.color.green), BLUE(
+        R.color.blue,
+    )
 }

--- a/app/src/main/java/woowacourse/paint/palette/Color.kt
+++ b/app/src/main/java/woowacourse/paint/palette/Color.kt
@@ -1,0 +1,8 @@
+package woowacourse.paint.palette
+
+import androidx.annotation.ColorRes
+import woowacourse.paint.R
+
+enum class Color(@ColorRes val resId: Int) {
+    RED(R.color.red), ORANGE(R.color.orange), YELLOW(R.color.yellow), GREEN(R.color.green), BLUE(R.color.blue)
+}

--- a/app/src/main/java/woowacourse/paint/palette/ColorSelectorAdapter.kt
+++ b/app/src/main/java/woowacourse/paint/palette/ColorSelectorAdapter.kt
@@ -1,0 +1,19 @@
+package woowacourse.paint.palette
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class ColorSelectorAdapter(private val onItemClick: (Int) -> Unit) :
+    RecyclerView.Adapter<ColorSelectorViewHolder>() {
+
+    private val colors = Color.values()
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ColorSelectorViewHolder =
+        ColorSelectorViewHolder(parent, onItemClick)
+
+    override fun getItemCount(): Int = colors.size
+
+    override fun onBindViewHolder(holder: ColorSelectorViewHolder, position: Int) {
+        holder.bind(colors[position])
+    }
+}

--- a/app/src/main/java/woowacourse/paint/palette/ColorSelectorViewHolder.kt
+++ b/app/src/main/java/woowacourse/paint/palette/ColorSelectorViewHolder.kt
@@ -8,14 +8,17 @@ import woowacourse.paint.databinding.ColorBoxItemBinding
 
 class ColorSelectorViewHolder(
     parent: ViewGroup,
-    private val onItemClick: (Int) -> Unit,
+    onItemClick: (Int) -> Unit,
 ) : RecyclerView.ViewHolder(
     LayoutInflater.from(parent.context).inflate(R.layout.color_box_item, parent, false),
 ) {
     private val binding = ColorBoxItemBinding.bind(itemView)
 
+    init {
+        binding.colorClickListener = onItemClick
+    }
+
     fun bind(item: Color) {
         binding.color = item
-        binding.colorClickListener = onItemClick
     }
 }

--- a/app/src/main/java/woowacourse/paint/palette/ColorSelectorViewHolder.kt
+++ b/app/src/main/java/woowacourse/paint/palette/ColorSelectorViewHolder.kt
@@ -1,0 +1,21 @@
+package woowacourse.paint.palette
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import woowacourse.paint.R
+import woowacourse.paint.databinding.ColorBoxItemBinding
+
+class ColorSelectorViewHolder(
+    parent: ViewGroup,
+    private val onItemClick: (Int) -> Unit,
+) : RecyclerView.ViewHolder(
+    LayoutInflater.from(parent.context).inflate(R.layout.color_box_item, parent, false),
+) {
+    private val binding = ColorBoxItemBinding.bind(itemView)
+
+    fun bind(item: Color) {
+        binding.color = item
+        binding.colorClickListener = onItemClick
+    }
+}

--- a/app/src/main/java/woowacourse/paint/palette/Palette.kt
+++ b/app/src/main/java/woowacourse/paint/palette/Palette.kt
@@ -11,12 +11,26 @@ import woowacourse.paint.R
 import woowacourse.paint.databinding.PaletteBinding
 
 class Palette(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
+
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        onSelectedColorIdChangedListener: (Int) -> Unit,
+        onStrokeWidthChangedListener: (Float) -> Unit,
+    ) : this(context, attrs) {
+        this.onSelectedColorIdChangedListener = onSelectedColorIdChangedListener
+        this.onStrokeWidthChangedListener = onStrokeWidthChangedListener
+    }
+
+    private lateinit var onSelectedColorIdChangedListener: (Int) -> Unit
+    private lateinit var onStrokeWidthChangedListener: ((Float) -> Unit)
+
     private val binding: PaletteBinding
 
     @ColorRes
-    var selectedColorId: Int = R.color.black
+    private var selectedColorId: Int = R.color.black
 
-    var strokeWidth: Float = 0f
+    private var strokeWidth: Float = 0f
         get() {
             return field + 10f
         }
@@ -32,6 +46,7 @@ class Palette(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(
     private fun initColorSelectorRecyclerView() {
         binding.rvColorSelector.adapter = ColorSelectorAdapter {
             selectedColorId = it
+            onSelectedColorIdChangedListener(it)
         }
     }
 
@@ -46,6 +61,7 @@ class Palette(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(
         binding.rangeSliderStrokeWidthSelector.addOnChangeListener(
             RangeSlider.OnChangeListener { _, value, _ ->
                 strokeWidth = value
+                onStrokeWidthChangedListener(strokeWidth)
             },
         )
     }

--- a/app/src/main/java/woowacourse/paint/palette/Palette.kt
+++ b/app/src/main/java/woowacourse/paint/palette/Palette.kt
@@ -12,16 +12,6 @@ import woowacourse.paint.databinding.PaletteBinding
 
 class Palette(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
 
-    constructor(
-        context: Context,
-        attrs: AttributeSet? = null,
-        onSelectedColorIdChangedListener: (Int) -> Unit,
-        onStrokeWidthChangedListener: (Float) -> Unit,
-    ) : this(context, attrs) {
-        this.onSelectedColorIdChangedListener = onSelectedColorIdChangedListener
-        this.onStrokeWidthChangedListener = onStrokeWidthChangedListener
-    }
-
     private lateinit var onSelectedColorIdChangedListener: (Int) -> Unit
     private lateinit var onStrokeWidthChangedListener: ((Float) -> Unit)
 
@@ -41,6 +31,16 @@ class Palette(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(
         initColorSelectorRecyclerView()
         initStrokeWidthSelector()
         initStrokeWidthSelectorListener()
+    }
+
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        onSelectedColorIdChangedListener: (Int) -> Unit,
+        onStrokeWidthChangedListener: (Float) -> Unit,
+    ) : this(context, attrs) {
+        this.onSelectedColorIdChangedListener = onSelectedColorIdChangedListener
+        this.onStrokeWidthChangedListener = onStrokeWidthChangedListener
     }
 
     private fun initColorSelectorRecyclerView() {

--- a/app/src/main/java/woowacourse/paint/palette/Palette.kt
+++ b/app/src/main/java/woowacourse/paint/palette/Palette.kt
@@ -10,7 +10,7 @@ import com.google.android.material.slider.RangeSlider
 import woowacourse.paint.R
 import woowacourse.paint.databinding.PaletteBinding
 
-class Palette(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
+class Palette(context: Context, attrs: AttributeSet? = null) : ConstraintLayout(context, attrs) {
     private val binding: PaletteBinding
 
     @ColorRes

--- a/app/src/main/java/woowacourse/paint/palette/Palette.kt
+++ b/app/src/main/java/woowacourse/paint/palette/Palette.kt
@@ -1,0 +1,52 @@
+package woowacourse.paint.palette
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.annotation.ColorRes
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.databinding.DataBindingUtil
+import com.google.android.material.slider.RangeSlider
+import woowacourse.paint.R
+import woowacourse.paint.databinding.PaletteBinding
+
+class Palette(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
+    private val binding: PaletteBinding
+
+    @ColorRes
+    var selectedColorId: Int = R.color.black
+
+    var strokeWidth: Float = 0f
+        get() {
+            return field + 10f
+        }
+
+    init {
+        binding =
+            DataBindingUtil.inflate(LayoutInflater.from(context), R.layout.palette, this, true)
+        initColorSelectorRecyclerView()
+        initStrokeWidthSelector()
+        initStrokeWidthSelectorListener()
+    }
+
+    private fun initColorSelectorRecyclerView() {
+        binding.rvColorSelector.adapter = ColorSelectorAdapter {
+            selectedColorId = it
+        }
+    }
+
+    private fun initStrokeWidthSelector() {
+        binding.rangeSliderStrokeWidthSelector.apply {
+            valueFrom = 0.0f
+            valueTo = 40.0f
+        }
+    }
+
+    private fun initStrokeWidthSelectorListener() {
+        binding.rangeSliderStrokeWidthSelector.addOnChangeListener(
+            RangeSlider.OnChangeListener { _, value, _ ->
+                strokeWidth = value
+            },
+        )
+    }
+}

--- a/app/src/main/res/drawable/bg_test.xml
+++ b/app/src/main/res/drawable/bg_test.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:centerColor="#b4b4b4"
+        android:endColor="#FFFFFF"
+        android:startColor="#000000"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,10 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <data>
-
-    </data>
-
     <woowacourse.paint.board.PaintBoard
         android:id="@+id/paint_board"
         android:background="@drawable/bg_test"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,9 +7,10 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <woowacourse.paint.board.PaintBoard
+        android:id="@+id/paint_board"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </woowacourse.paint.board.PaintBoard>
 </layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    xmlns:tools="http://schemas.android.com/tools">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,6 +9,7 @@
 
     <woowacourse.paint.board.PaintBoard
         android:id="@+id/paint_board"
+        android:background="@drawable/bg_test"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 

--- a/app/src/main/res/layout/color_box_item.xml
+++ b/app/src/main/res/layout/color_box_item.xml
@@ -27,7 +27,6 @@
             android:onClick="@{()->colorClickListener.invoke(color.resId)}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.8"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:setBackGroundColor="@{color.resId}"

--- a/app/src/main/res/layout/color_box_item.xml
+++ b/app/src/main/res/layout/color_box_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="color"
+            type="woowacourse.paint.palette.Color" />
+
+        <variable
+            name="colorClickListener"
+            type="kotlin.jvm.functions.Function1" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_color"
+            android:layout_width="70dp"
+            android:layout_height="70dp"
+            android:layout_margin="10dp"
+            android:onClick="@{()->colorClickListener.invoke(color.resId)}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.8"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:setBackGroundColor="@{color.resId}"
+            tools:background="@color/black" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/palette.xml
+++ b/app/src/main/res/layout/palette.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_color_selector"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:itemCount="5"
+            tools:listitem="@layout/color_box_item" />
+
+
+        <com.google.android.material.slider.RangeSlider
+            android:id="@+id/range_slider_stroke_width_selector"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@+id/rv_color_selector" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/palette.xml
+++ b/app/src/main/res/layout/palette.xml
@@ -26,8 +26,10 @@
 
         <com.google.android.material.slider.RangeSlider
             android:id="@+id/range_slider_stroke_width_selector"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/rv_color_selector" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,9 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="red">#FF0000</color>
+    <color name="orange">#FF9800</color>
+    <color name="yellow">#FFEB3B</color>
+    <color name="green">#4CAF50</color>
+    <color name="blue">#3F51B5</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Paint" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.Paint" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
안녕하세요 글로 선생님 눈물의 멧돼지입니다.
이번미션 재미있어보이고 추석이기도 해서 자체 미션을 부여해서 해봤는데 처참히 말아먹어서 조금 슬프네요
이틀남기고 요이땅 시작해서 한거라 좀 코드를 정돈하지 못했습니다. 이렇게 리펙터링안하고 엉망으로 짠게 오랫만인거 같은데요 잠좀자고 오늘 밤에 다시 고쳐보겠습니다.

제출하는 현재 친구들이 지금 추석이라고 제방에 쳐들어와 누워서 데모하고있어서 마저 리펙을 하지못했습니다 죄송합니다

일단 이번 미션에 구현한 사항은 이렇습니다.
### 그림판이니까 도화지를 크게

보드 자체를 화면크기의 세로는 5배 가로는 15배로 설정하고 두손가락 드래그를 통해 끌어서 사용하게 만들어 넓은 도화지를 사용할수 있도록 하였습니다.

### 핀치줌, 두손가락 드래그

각각은 구현했는데 함께 사용하니 이상하게 동작해서 일단 두손가락 드래그만 적용해놨습니다. 
이에대한 해결방법으로 세손가락으로 드래그를 구현할 까 생각중입니다. 
이것때문에 이틀밤동안 이것저것 다 시도해봤는데 구글 컴포넌트 자체를 이상하게 만들어서(ScaleGestureDetector.SimpleOnScaleGestureListener() 두손가락 이벤트만 처리하게 되어있는 pointer 한개여도 true로 반환하여 처리 불가하게 만듬)구글에 사람들이 화내는것도 봤고 어쨋든 다사다난하게 온갖거 다해보고 실패했습니다.
지금와서 레퍼런스를 이것저것 찾아보니 두손가락 액션을 하나만 지정하더라고요 포인터 두개에 여러 동작을 우겨넣는것 자체가 기술적으로 어렵거나 애매한것 같습니다.(네이버 지도만 줌과 각도 조정이 동시에 됨)
   
또한 현재 드래그에도 약간의 버그가 있습니다. -> 두손가락을 동시에 떼어야 선그리는것으로 인식안하는 현상
이는 포인터를 관리하면 해결될것같은데 시간이 없어서 넘겼습니다. 이것은 추후에 고쳐보겠습니다.
   
핀치줌도 ScaleGestureDetector만 변경해보시면 동작하는것을 확인하실수 있습니다.
핀치줌:PinchZoomListener, 두손가락 드래그: TwoPointerDragListener

### palette sticky하게 따라다니게 하기
그림판 크기를 늘려놓다보니 팔레트 뷰가 화면을 쫓아다니는것도 계산해줘야하더라고요 여기서부터 시간이 없어서 쫓기면서 엉망으로 했습니다. ㅠㅠㅠ 어쩃든 잘 쫓아다니긴합니다.  나중에 깨끗하게 리펙해볼게요

어쩃든 뭐 이래저래 요구사항은 다 만족했습니다. 예쁘게 봐주세요

p.s 배경 그라데이션으로 깔아놓았는데 그건 화면이동좀 확인하려고 깔아놓았습니다. 이동하는거 확인하기 좋아요 ㅎㅎㅎ